### PR TITLE
Jump into C

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,40 +1,49 @@
 ASM=nasm
+CC=gcc
+LD=ld
 SRC_DIR=src
 BUILD_DIR=build
 
+CFLAGS=-ffreestanding -m64 -nostdlib -O2 -Wall
+LDFLAGS=-T $(SRC_DIR)/kernel/kernel.ld -nostdlib -z max-page-size=0x1000
 
 # Floppy disk
-floppy_image: $(BUILD_DIR)/main.img                                                   # Alias for commandline (i.e., make floppy_image)
-$(BUILD_DIR)/main.img: stage0 stage1 kernel                                              # Target
+floppy_image: $(BUILD_DIR)/main.img
+$(BUILD_DIR)/main.img: stage0 stage1 kernel
 	dd if=/dev/zero of=$(BUILD_DIR)/main.img bs=512 count=2880
 	mkfs.fat -F 12 -n "SNAKEOS" $(BUILD_DIR)/main.img
 	dd if=$(BUILD_DIR)/stage0.bin of=$(BUILD_DIR)/main.img conv=notrunc
 	mcopy -i $(BUILD_DIR)/main.img $(BUILD_DIR)/stage1.bin "::stage1.bin"
-	mcopy -i $(BUILD_DIR)/main.img $(BUILD_DIR)/kernel_entry.bin "::kernel.bin"
- 
-# Bootloader 
-stage0: $(BUILD_DIR)/stage0.bin 											      # Alias for commandline (i.e., make bootloader)
-$(BUILD_DIR)/stage0.bin:                                                          # Target
-	$(ASM) $(SRC_DIR)/bootloader/stage0/stage0.asm -f bin -o $(BUILD_DIR)/stage0.bin 
+	mcopy -i $(BUILD_DIR)/main.img $(BUILD_DIR)/kernel.bin "::kernel.bin"
+
+# Bootloader
+stage0: $(BUILD_DIR)/stage0.bin
+$(BUILD_DIR)/stage0.bin:
+	$(ASM) $(SRC_DIR)/bootloader/stage0/stage0.asm -f bin -o $(BUILD_DIR)/stage0.bin
 
 # Stage 1
 stage1: $(BUILD_DIR)/stage1.bin
 $(BUILD_DIR)/stage1.bin:
 	$(ASM) $(SRC_DIR)/bootloader/stage1/stage1.asm -f bin -o $(BUILD_DIR)/stage1.bin
 
+# Kernel
+kernel: $(BUILD_DIR)/kernel.bin
+$(BUILD_DIR)/kernel.bin: $(BUILD_DIR)/kernel_entry.o $(BUILD_DIR)/main.o $(SRC_DIR)/kernel/kernel.ld
+	$(LD) $(LDFLAGS) -o $(BUILD_DIR)/kernel.bin $(BUILD_DIR)/kernel_entry.o $(BUILD_DIR)/main.o
 
-# Kernel 
-kernel: $(BUILD_DIR)/kernel_entry.bin                                                       # Alias for commandline (i.e., make kernel)
-$(BUILD_DIR)/kernel_entry.bin:                                                              # Target
-	$(ASM) $(SRC_DIR)/kernel/kernel_entry.asm -f bin -o $(BUILD_DIR)/kernel_entry.bin
+$(BUILD_DIR)/kernel_entry.o: $(SRC_DIR)/kernel/kernel_entry.asm
+	$(ASM) -f elf64 $< -o $@
 
-# Run OS without gdb debug
+$(BUILD_DIR)/main.o: $(SRC_DIR)/kernel/main.c
+	$(CC) $(CFLAGS) -c $< -o $@
+
+# Run
 run:
-	qemu-system-x86_64 -fda build/main.img
+	qemu-system-x86_64 -fda $(BUILD_DIR)/main.img
 
-# This one doesn't build .iso! Run chmod +x script.sh to give script premission to execute.
+# Debug
 debug:
 	./debug.sh
 
 clean:
-	rm -rf $(BUILD_DIR)/*.bin $(BUILD_DIR)/*.img
+	rm -rf $(BUILD_DIR)/*.bin $(BUILD_DIR)/*.img $(BUILD_DIR)/*.o

--- a/src/bootloader/stage1/stage1.asm
+++ b/src/bootloader/stage1/stage1.asm
@@ -64,7 +64,7 @@ start_protected_mode:
 
     ; Inform protected mode is entered
     mov esi, MSG_PROT_MODE
-    call print_32_bits                        ; ESI = pinter to the message
+    call print_32_bits                        ; ESI = pointer to the message; PRINT_STRING_POSSITION = video memory address
 
     ; Clean general purpose registers from print_string_pm
     xor ebx, ebx
@@ -107,12 +107,12 @@ start_long_mode:
     mov ss, ax
 
     ; Inform long mode was entabled
-    mov esi, long_mode_enabled
-    call print_string_64
+    mov rsi, long_mode_enabled
+    call print_64_bits                        ; RSI = string address; PRINT_STRING_POSSITION = video memory address
     
     ; Jump to the kernel_entry.asm
-    mov rax, [PRINT_STRING_POSSITION]         ; Save print string position into RAX
-    jmp kernel_load_offset
+    mov eax, [PRINT_STRING_POSSITION]         ; Save print string position into RAX (was initiated in protected mode => 32 bits, must use eax)
+    jmp kernel_load_offset                    ; Jump to the keranel loaded by stage1. Address is the same since first 1 GiB was identity mapped (physical = virtual address)
 
     hlt
     jmp $
@@ -120,4 +120,4 @@ start_long_mode:
 %include "./src/bootloader/stage1/utils_long_mode.asm"
 long_mode_enabled db "MODE ENTERED: Long", 0
 kernel_load_offset equ 0x90000                ; Stage0 loaded kernel.bin at this offset (stayed the same since)
-                                              ; first 1 GiB was identity mapped (physical = virtual address)
+                                              

--- a/src/bootloader/stage1/stage1.asm
+++ b/src/bootloader/stage1/stage1.asm
@@ -103,7 +103,7 @@ start_long_mode:
     mov ss, ax
 
     ; Inform long mode was entabled
-    mov rsi, long_mode_enabled
+    mov rdi, long_mode_enabled
     call print_64_bits                        ; RSI = string address; PRINT_STRING_POSSITION = video memory address
     
     ; Jump to the kernel_entry.asm

--- a/src/bootloader/stage1/stage1.asm
+++ b/src/bootloader/stage1/stage1.asm
@@ -67,8 +67,8 @@ start_protected_mode:
     call print_32_bits                        ; ESI = pointer to the message; PRINT_STRING_POSSITION = video memory address
 
     ; Clean general purpose registers from print_string_pm
-    xor ebx, ebx
-    xor ecx, ecx
+    ; xor ebx, ebx
+    ; xor ecx, ecx
 
     ; Check if long mode is supported
     call check_CPUID                          ; Esure CPUID instruction is supported

--- a/src/bootloader/stage1/stage1.asm
+++ b/src/bootloader/stage1/stage1.asm
@@ -53,7 +53,7 @@ bits 32
 start_protected_mode:
     
     ; Move correct GDT index into segment registers (ds=0x8000 => no such entry in GDT)
-    mov ax, DATA_SEG ; 0x8010f
+    mov ax, DATA_SEG                          ; 0x8010f
     mov ds, ax
     mov es, ax
     mov ss, ax
@@ -65,10 +65,6 @@ start_protected_mode:
     ; Inform protected mode is entered
     mov esi, MSG_PROT_MODE
     call print_32_bits                        ; ESI = pointer to the message; PRINT_STRING_POSSITION = video memory address
-
-    ; Clean general purpose registers from print_string_pm
-    ; xor ebx, ebx
-    ; xor ecx, ecx
 
     ; Check if long mode is supported
     call check_CPUID                          ; Esure CPUID instruction is supported

--- a/src/bootloader/stage1/utils_long_mode.asm
+++ b/src/bootloader/stage1/utils_long_mode.asm
@@ -12,30 +12,30 @@ RED_ON_BLACK    equ 0x0C
 BYTES_PER_CHAR  equ 2
 
 print_64_bits:
-    push rdi
+    push rsi
     push rsi
     push rax
     xor rax, rax
-    xor rdi, rdi
-    mov edi, [PRINT_STRING_POSSITION]         ; Start writing at top-left corner of screen (0x80280)
-    push rdi                                  ; Save original PRINT_STRING_POSSITION to add +160 for printing on the next line 
+    xor rsi, rsi
+    mov esi, [PRINT_STRING_POSSITION]         ; Start writing at top-left corner of screen (0x80280)
+    push rsi                                  ; Save original PRINT_STRING_POSSITION to add +160 for printing on the next line 
 
 .print_loop:
-    mov al, [rsi]                             ; Load next character (since paging is enabled => 64 bit addresses)
+    mov al, [rdi]                             ; Load next character (since paging is enabled => 64 bit addresses)
     cmp al, 0                                 ; Check if it is the end of the string
     je .done
 
     mov ah, RED_ON_BLACK                      ; Attribute: red on black
-    mov [rdi], ax                             ; Write character and attribute
-    add rsi, 1                                ; Next character in string
-    add rdi, BYTES_PER_CHAR                   ; Next position in video memory
+    mov [rsi], ax                             ; Write character and attribute
+    add rdi, 1                                ; Next character in string
+    add rsi, BYTES_PER_CHAR                   ; Next position in video memory
     jmp .print_loop
 
 .done:
-    pop rdi
-    add rdi, 160                              ; Screen is 80 characters long => 80*2 = 160 for video memory for the next line
-    mov [PRINT_STRING_POSSITION], rdi         ; Preserve next video memory to print on
-    pop rax
     pop rsi
+    add rsi, 160                              ; Screen is 80 characters long => 80*2 = 160 for video memory for the next line
+    mov [PRINT_STRING_POSSITION], rsi         ; Preserve next video memory to print on
+    pop rax
     pop rdi
+    pop rsi
     ret

--- a/src/bootloader/stage1/utils_long_mode.asm
+++ b/src/bootloader/stage1/utils_long_mode.asm
@@ -1,6 +1,6 @@
 ; ===========================| Print_64_bits |============================
 ; Input:
-;   - ESI = pointer to the string
+;   - RSI = pointer to the string (should be 64 bits register since paging is on)
 ;   - PRINT_STRING_POSSITION = byte for the string start (will be moved to RDI)
 ; Output:
 ;   - Save next address to print the string into PRINT_STRING_POSSITION

--- a/src/bootloader/stage1/utils_long_mode.asm
+++ b/src/bootloader/stage1/utils_long_mode.asm
@@ -1,32 +1,40 @@
-bits 64
+; ===========================| Print_64_bits |============================
+; Input:
+;   - ESI = pointer to the string
+;   - PRINT_STRING_POSSITION = byte for the string start (will be moved to RDI)
+; Output:
+;   - Save next address to print the string into PRINT_STRING_POSSITION
+;   - ESI is cleaned to 0. Everything else in untouched
+; ==============================================================
+
 
 RED_ON_BLACK    equ 0x0C
 BYTES_PER_CHAR  equ 2
 
-print_string_64:
+print_64_bits:
     push rdi
     push rsi
     push rax
     xor rax, rax
     xor rdi, rdi
     mov edi, [PRINT_STRING_POSSITION]         ; Start writing at top-left corner of screen (0x80280)
-    push rdi
+    push rdi                                  ; Save original PRINT_STRING_POSSITION to add +160 for printing on the next line 
 
 .print_loop:
-    mov al, [rsi]                 ; Load next character
-    cmp al, 0                     ; End of string?
+    mov al, [rsi]                             ; Load next character (since paging is enabled => 64 bit addresses)
+    cmp al, 0                                 ; Check if it is the end of the string
     je .done
 
-    mov ah, RED_ON_BLACK          ; Attribute: red on black
-    mov [rdi], ax                 ; Write character and attribute
-    add rsi, 1                    ; Next character in string
-    add rdi, BYTES_PER_CHAR       ; Next position in video memory
+    mov ah, RED_ON_BLACK                      ; Attribute: red on black
+    mov [rdi], ax                             ; Write character and attribute
+    add rsi, 1                                ; Next character in string
+    add rdi, BYTES_PER_CHAR                   ; Next position in video memory
     jmp .print_loop
 
 .done:
     pop rdi
-    add rdi, 160
-    mov [PRINT_STRING_POSSITION], rdi
+    add rdi, 160                              ; Screen is 80 characters long => 80*2 = 160 for video memory for the next line
+    mov [PRINT_STRING_POSSITION], rdi         ; Preserve next video memory to print on
     pop rax
     pop rsi
     pop rdi

--- a/src/bootloader/stage1/utils_real_mode.asm
+++ b/src/bootloader/stage1/utils_real_mode.asm
@@ -102,13 +102,13 @@ gdt_start:
         db 11001111b                          ; flags (4 bits) + last 4 bits of limit
         db 0x0                                ; segment base, bits 24-31
 
-    ; LIMIT = BASE = 0 since ignored
+    ; LIMIT = BASE = 0 since ignored.
     .long_mode_code_descriptor:
         dw 0x0000                             ; Limit (ignored)
         dw 0x0000                             ; Base[15:0]
         db 0x00                               ; Base[23:16]
         db 10011010b                          ; Access: exec/read, present
-        db 00100000b                          ; Flags: L=1, D=0
+        db 00100000b                          ; Have a flag for a 64-bit mode
         db 0x00                               ; Base[31:24]
 
     CODE_SEG equ .code_descriptor - gdt_start ; Offset to the code segment (will be 8 bytes)    

--- a/src/kernel/kernel.ld
+++ b/src/kernel/kernel.ld
@@ -1,7 +1,7 @@
 OUTPUT_FORMAT("binary")
 ENTRY(kernel_main)
-
 SECTIONS {
+    STACK_TOP = 0x80000;
     . = 0x90000;
     .text : { *(.text*) }
     .rodata : { *(.rodata*) }

--- a/src/kernel/kernel_entry.asm
+++ b/src/kernel/kernel_entry.asm
@@ -8,7 +8,7 @@ extern main
 kernel_entry:
     mov [PRINT_STRING_POSSITION], rax                    ; Save line 
     mov esi, MSG_KERNEL
-    call print_string_64
+    call print_64_bits
     ; call main
     hlt
     jmp $

--- a/src/kernel/kernel_entry.asm
+++ b/src/kernel/kernel_entry.asm
@@ -1,18 +1,19 @@
-org 0x90000
+; org 0x90000
 bits 64
 
 global kernel_entry
-global print_string_64
+global print_64_bits
 extern main
+
+PRINT_STRING_POSSITION dq 0                              ; Position for the next string                              
 
 kernel_entry:
     mov [PRINT_STRING_POSSITION], rax                    ; Save line 
-    mov esi, MSG_KERNEL
+    mov rdi, MSG_KERNEL
     call print_64_bits
-    ; call main
+    call main
     hlt
     jmp $
 
 %include "./src/bootloader/stage1/utils_long_mode.asm"
 MSG_KERNEL db "SUCCESSFUL: Kernel entry loaded. Loading the kernel...", 0x00
-PRINT_STRING_POSSITION dw 0

--- a/src/kernel/main.c
+++ b/src/kernel/main.c
@@ -1,11 +1,13 @@
 // main.c
-void print_string_64(const char* str);
+/*
+    With -m64 gcc flag, function arguments are as follows:
+    (1) RDI (2) RSI (3) RDX (4) RCX (5) R8 (6) R9
 
-void kernel_main() {
-    print_string_64("Hello from C kernel!\0");
+*/
 
-    // Halt forever
-    while (1) {
-        __asm__ __volatile__("hlt");
-    }
+extern void print_64_bits(const char* str);
+
+void main() {
+    print_64_bits("Hello from C!\0");
+    while (1) __asm__("hlt");
 }


### PR DESCRIPTION
- Make sure rdi is used for the string pointer since it is used as the first argument for C functions
- Align function names in `kernel_entry.asm` and `main.c`
- Adjust linking script
- Change Makefile to link the kernel