### PR TITLE
Initialize PIC and enable timer interrupts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,8 +37,8 @@ $(BUILD_DIR)/stage1.bin:
 
 # === Kernel ===
 kernel: $(BUILD_DIR)/kernel.elf $(BUILD_DIR)/kernel.bin
-$(BUILD_DIR)/kernel.elf: $(BUILD_DIR)/kernel_entry.o $(BUILD_DIR)/kmain.o $(BUILD_DIR)/kprint.o $(BUILD_DIR)/gdt.o $(BUILD_DIR)/gdt_asm.o $(BUILD_DIR)/util.o $(BUILD_DIR)/idt.o $(BUILD_DIR)/isr.o $(BUILD_DIR)/isr_asm.o $(BUILD_DIR)/timer.o $(SRC_DIR)/kernel/impl/kernel.ld 
-	$(LD) $(LDFLAGS) -o $@ $(BUILD_DIR)/kernel_entry.o $(BUILD_DIR)/kmain.o $(BUILD_DIR)/kprint.o $(BUILD_DIR)/gdt.o $(BUILD_DIR)/gdt_asm.o $(BUILD_DIR)/util.o $(BUILD_DIR)/idt.o $(BUILD_DIR)/isr.o $(BUILD_DIR)/isr_asm.o $(BUILD_DIR)/timer.o
+$(BUILD_DIR)/kernel.elf: $(BUILD_DIR)/kernel_entry.o $(BUILD_DIR)/kmain.o $(BUILD_DIR)/kprint.o $(BUILD_DIR)/gdt.o $(BUILD_DIR)/gdt_asm.o $(BUILD_DIR)/util.o $(BUILD_DIR)/idt.o $(BUILD_DIR)/isr.o $(BUILD_DIR)/isr_asm.o $(BUILD_DIR)/timer.o $(BUILD_DIR)/pic.o $(SRC_DIR)/kernel/impl/kernel.ld
+	$(LD) $(LDFLAGS) -o $@ $(BUILD_DIR)/kernel_entry.o $(BUILD_DIR)/kmain.o $(BUILD_DIR)/kprint.o $(BUILD_DIR)/gdt.o $(BUILD_DIR)/gdt_asm.o $(BUILD_DIR)/util.o $(BUILD_DIR)/idt.o $(BUILD_DIR)/isr.o $(BUILD_DIR)/isr_asm.o $(BUILD_DIR)/timer.o $(BUILD_DIR)/pic.o
 $(BUILD_DIR)/kernel.bin: $(BUILD_DIR)/kernel.elf
 	objcopy -O binary $< $@
 
@@ -62,6 +62,8 @@ $(BUILD_DIR)/idt.o: $(SRC_DIR)/kernel/impl/interrupts/idt.c
 $(BUILD_DIR)/isr.o: $(SRC_DIR)/kernel/impl/interrupts/isr.c
 	$(CC) $(CFLAGS) -c $< -o $@
 $(BUILD_DIR)/timer.o: $(SRC_DIR)/kernel/impl/timer.c
+	$(CC) $(CFLAGS) -c $< -o $@
+$(BUILD_DIR)/pic.o: $(SRC_DIR)/kernel/impl/interrupts/pic.c
 	$(CC) $(CFLAGS) -c $< -o $@
 
 # === Run ===

--- a/src/kernel/impl/interrupts/pic.c
+++ b/src/kernel/impl/interrupts/pic.c
@@ -1,0 +1,33 @@
+#include "stdint.h"
+#include "ports.h"
+
+#define PIC1_CMD   0x20
+#define PIC1_DATA  0x21
+#define PIC2_CMD   0xA0
+#define PIC2_DATA  0xA1
+
+#define ICW1_INIT  0x10
+#define ICW1_ICW4  0x01
+#define ICW4_8086  0x01
+
+void pic_init(void) {
+    // Start initialization sequence (cascade mode, expect ICW4)
+    outb(PIC1_CMD, ICW1_INIT | ICW1_ICW4);
+    outb(PIC2_CMD, ICW1_INIT | ICW1_ICW4);
+
+    // Remap offsets: master to 0x20 (32), slave to 0x28 (40)
+    outb(PIC1_DATA, 0x20);
+    outb(PIC2_DATA, 0x28);
+
+    // Setup cascading
+    outb(PIC1_DATA, 0x04); // Tell master that slave is at IRQ2
+    outb(PIC2_DATA, 0x02); // Tell slave its cascade identity
+
+    // Environment info
+    outb(PIC1_DATA, ICW4_8086);
+    outb(PIC2_DATA, ICW4_8086);
+
+    // Mask all IRQs except IRQ0 (timer)
+    outb(PIC1_DATA, 0xFE);
+    outb(PIC2_DATA, 0xFF);
+}

--- a/src/kernel/impl/kmain.c
+++ b/src/kernel/impl/kmain.c
@@ -8,6 +8,7 @@
 #include "kprint.h"
 #include "gdt.h"
 #include "idt.h"
+#include "pic.h"
 
 extern void print_64_bits(const char* str);
 extern void init_timer(uint32_t freq);
@@ -18,8 +19,10 @@ void kmain() {
     kprint("This is my string\n");
     gdtInit();
     idtInit();
+    pic_init();
     kprint("This is my second string!!!\n");
     init_timer(100);
+    __asm__ volatile ("sti");
     kprint("Is timer working?\n");
     while (1) __asm__("hlt");
 }

--- a/src/kernel/intf/pic.h
+++ b/src/kernel/intf/pic.h
@@ -1,0 +1,3 @@
+#pragma once
+
+void pic_init(void);


### PR DESCRIPTION
## Summary
- Add a PIC initialization routine that remaps master and slave PICs and unmasks IRQ0.
- Integrate PIC setup into kernel boot sequence and enable interrupts after timer init.
- Include new PIC code in the build system.

## Testing
- `make clean`
- `make kernel`